### PR TITLE
Hotfix: Win Perc Rounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,3 @@ To run the code:
  1. Fork the repo
  2. Run `npm install`
  3. Run `npm run dev`
-
-ahhhhh

--- a/app/components/PlayerTable/PlayerTable.tsx
+++ b/app/components/PlayerTable/PlayerTable.tsx
@@ -81,7 +81,7 @@ const PlayerTable = forwardRef<HTMLTableElement, IPlayerTableProps>(({ tableData
               <td align="center">{player.wins}</td>
               <td align="center">{player.losses}</td>
               <td align="center">{player.matchesPlayed}</td>
-              <td align="center">{Math.round(player.winPerc)}%</td>
+              <td align="center">{player.winPerc}%</td>
             </tr>
           );
         })}

--- a/app/routes/leaderboard.tsx
+++ b/app/routes/leaderboard.tsx
@@ -30,7 +30,7 @@ export const loader: LoaderFunction = async (): Promise<Array<Player>> => {
     wins: player.Wins,
     losses: player.Losses,
     matchesPlayed: player.Wins + player.Losses,
-    winPerc: player.Wins / (player.Wins + player.Losses),
+    winPerc: Math.round((player.Wins / (player.Wins + player.Losses)) * 100),
   }));
   return calculatedRanks;
 };

--- a/app/routes/winners.tsx
+++ b/app/routes/winners.tsx
@@ -44,7 +44,7 @@ export const loader: LoaderFunction = async (): Promise<WinnerLoaderResponse> =>
       wins: winner.Wins,
       losses: winner.Losses,
       matchesPlayed: winner.Wins + winner.Losses,
-      winPerc: winner.Wins / (winner.Wins + winner.Losses),
+      winPerc: Math.round((winner.Wins / (winner.Wins + winner.Losses)) * 100),
     }));
     winners.set(season, calculatedSeasonWinners);
   }

--- a/app/styles/global.css
+++ b/app/styles/global.css
@@ -46,8 +46,8 @@ hr {
 }
 
 ::-webkit-scrollbar {
-  width: 5px;
-  height: 5px;
+  width: 8px;
+  height: 8px;
 }
 ::-webkit-scrollbar-thumb {
   background: var(--grey-600);


### PR DESCRIPTION
The win percentages all show as 1% or 0% right now since we're trying to show a decimal value as a percentage without multiplying by 100. This PR fixes that as well as revert the README test and increases the scroll bar size by a few pixels to make it easier to grab.